### PR TITLE
Improved python3 interoperability changing to print functions and <> to !=

### DIFF
--- a/GeneList.py
+++ b/GeneList.py
@@ -115,7 +115,7 @@ class Genelist():
             self.ngenes += 1
 
     def selectChrom(self, chrom):
-        if chrom <> self.currentChrom and chrom in self.chroms:
+        if chrom != self.currentChrom and chrom in self.chroms:
             self.currentChrom = chrom
             self.currentGenes = self.genes[chrom]
         return self.currentGenes
@@ -158,15 +158,15 @@ class Genelist():
         for chrom, genes in self.genes.iteritems():
             ng = len(genes)
             d = []
-            # print "chr={}, genes={}".format(chrom, len(genes))
+            # print("chr={}, genes={}".format(chrom, len(genes)))
             for i in range(0, len(genes), step):
                 i2 = min(i+step, ng) - 1
-                # print "i1={}, i2={}".format(i, i+step-1)
+                # print("i1={}, i2={}".format(i, i+step-1))
                 gfirst = genes[i]
                 glast  = genes[i2]
                 d.append([gfirst.start, glast.end, i, i2])
             idxs[chrom] = d
-            # print d
+            # print(d)
             # raw_input()
         self.indexes = idxs
 
@@ -225,7 +225,7 @@ class Genelist():
         self.selectChrom(chrom)
         genes = self.currentGenes
         (first, last) = self.positionsToRange(chrom, start, end)
-        # print "Looking at {}-{}".format(first, last)
+        # print("Looking at {}-{}".format(first, last))
         for i in range(first, last+1):
             ix = self.classifyIntersection(start, end, genes[i])
             if ix:
@@ -268,7 +268,7 @@ class Genelist():
                             out.write("{}\t{}\t{}\t{}_{}\t{}\t{}\n".format(chrom, start, end, gene.mrna, intid, gene.name, gene.strand))
                         else:
                             out.write("{}\t{}\t{}\t{}_{}\t{}\t{}\n".format(chrom, end, start, gene.mrna, intid, gene.name, gene.strand))
-                            # print [chrom, end, start, gene.mrna, intid, gene.name, gene.strand]
+                            # print([chrom, end, start, gene.mrna, intid, gene.name, gene.strand])
                             # raw_input()
                         intid += 1
                         prevexon = ex
@@ -423,14 +423,14 @@ class Transcript():
 
     def dump(self, prefix="", short=False):
         if short:
-            print "{}{} {}:{}-{} {}".format(prefix, self.ID, self.chrom, self.txstart, self.txend, self.exons)
+            print("{}{} {}:{}-{} {}".format(prefix, self.ID, self.chrom, self.txstart, self.txend, self.exons))
         else:
-            print prefix + "ID: " + self.ID
-            print prefix + "Chrom: " + self.chrom
-            print "{}Strand: {}".format(prefix, self.strand)
-            print "{}Transcript: {}-{}".format(prefix, self.txstart, self.txend)
-            print "{}CDS: {}-{}".format(prefix, self.cdsstart, self.cdsend)
-            print "{}Exons: {}".format(prefix, self.exons)
+            print(prefix + "ID: " + self.ID)
+            print(prefix + "Chrom: " + self.chrom)
+            print("{}Strand: {}".format(prefix, self.strand))
+            print("{}Transcript: {}-{}".format(prefix, self.txstart, self.txend))
+            print("{}CDS: {}-{}".format(prefix, self.cdsstart, self.cdsend))
+            print("{}Exons: {}".format(prefix, self.exons))
 
     def saveToDB(self, conn, parentID):
         idx = 0
@@ -632,14 +632,14 @@ class Gene():
         self.data        = []
 
     def dump(self):
-        print "ID: " + self.ID
-        print "Gene: " + self.name
-        print "GeneID: " + self.geneid
-        print "ENSG: " + self.ensg
-        print "Biotype: " + self.biotype
-        print "Region: {}:{}-{}".format(self.chrom, self.start, self.end)
-        print "Strand: {}".format(self.strand)
-        print "Transcripts:"
+        print("ID: " + self.ID)
+        print("Gene: " + self.name)
+        print("GeneID: " + self.geneid)
+        print("ENSG: " + self.ensg)
+        print("Biotype: " + self.biotype)
+        print("Region: {}:{}-{}".format(self.chrom, self.start, self.end))
+        print("Strand: {}".format(self.strand))
+        print("Transcripts:")
         for t in self.transcripts:
             t.dump(prefix="  ", short=True)
 
@@ -675,7 +675,7 @@ class Gene():
     def getRegion(self, params):
         """Returns the region for this gene as (start, end) according to the 'regwanted', 
 'updistance, and 'dndistance' attributes in the `params' object."""
-        #print self.name, self.start, self.end
+        #print(self.name, self.start, self.end)
         if self.start and self.end:
             if params.regwanted == 'b':
                 return (self.start, self.end)
@@ -795,9 +795,9 @@ class GenbankLoader(GeneLoader):
                     if key == '':   # still in previous section?
                         if section == 'gene':
                             data = line[21:]
-                            # print "In gene section: {}".format(data)
+                            # print("In gene section: {}".format(data))
                             if data[0:5] == '/gene':
-                                # print "Setting name to {}".format(data[7:-1])
+                                # print("Setting name to {}".format(data[7:-1]))
                                 thisGene.name = thisGene.ID = data[7:-1]
                             elif data[0:10] == '/locus_tag':
                                 if thisGene.name == '':
@@ -805,25 +805,25 @@ class GenbankLoader(GeneLoader):
                                 if thisGene.ID == '':
                                     thisGene.ID = data[12:-1]
                     elif key == 'gene':
-                        # print "Found new gene"
+                        # print("Found new gene")
                         # raw_input()
                         section = key
                         start, end, strand, ignore = parseStartEnd(line[21:])
-                        # print "New gene at ({}, {})".format(start, end)
+                        # print("New gene at ({}, {})".format(start, end))
                         thisGene = Gene("", chrom, strand)
                         thisGene.chrom = chrom
                         self.gl.add(thisGene, chrom)
                         thisGene.addTranscript(Transcript("", chrom, strand, start, end))
                     elif key == 'CDS':
                         cdsstart, cdsend, ignore, introns = parseStartEnd(line[21:])
-                        # print "Setting CDS to ({}, {})".format(cdsstart, cdsend)
+                        # print("Setting CDS to ({}, {})".format(cdsstart, cdsend))
                         if introns:
-                            # print "Setting introns: {}".format(introns)
+                            # print("Setting introns: {}".format(introns))
                             thisGene.transcripts[0].setIntrons(introns)
 
                         thisGene.transcripts[0].setCDS(cdsstart, cdsend)
-                        # print thisGene.smallrects
-                        # print thisGene.largerects
+                        # print(thisGene.smallrects)
+                        # print(thisGene.largerects)
                     else:
                         section = ''
                 elif line[0:9] == 'ACCESSION': # 'LOCUS':
@@ -849,9 +849,9 @@ class GTFloader(GeneLoader):
         """Read genes from a GTF file `filename'. If `wanted' is specified, only include genes whose biotype
 is in this list (or missing). If `notwanted' is specified, only include genes whose biotype is not in this list (or missing)."""
 
-        if wanted <> []:
+        if wanted != []:
             self.gl.setWanted(wanted)
-        elif notwanted <> []:
+        elif notwanted != []:
             self.gl.setNotWanted(notwanted)
 
         with open(self.filename, "r") as f:
@@ -872,7 +872,7 @@ is in this list (or missing). If `notwanted' is specified, only include genes wh
                     else:
                         self.currGene.name = ann['gene_id']
                     self.currGene.biotype = ann['gene_biotype']
-                    # print "Adding {} to {}".format(self.currGene.ID, chrom)
+                    # print("Adding {} to {}".format(self.currGene.ID, chrom))
                     # raw_input()
                     self.gl.add(self.currGene, chrom)
 
@@ -925,16 +925,16 @@ class GFFloader(GeneLoader):
         strand = 0
         orphans = 0             # Entries not following their parents
 
-        if wanted <> []:
+        if wanted != []:
             self.gl.setWanted(wanted)
-        elif notwanted <> []:
+        elif notwanted != []:
             self.gl.setNotWanted(notwanted)
 
         with open(self.filename, "r") as f:
             reader = Utils.CSVreader(f)
             for line in reader:
                 if len(line) < 8:
-                    print "|"+line+"|"
+                    print("|"+line+"|")
                 if line[6] == '+':
                     strand = 1
                 else:

--- a/Utils.py
+++ b/Utils.py
@@ -445,7 +445,7 @@ class Resampler():
         self.init(size1, size2)
 
     def init(self, size1, size2):
-        # print "Init, {}, {}".format(size1, size2)
+        # print("Init, {}, {}".format(size1, size2))
         if size1 == 0 or size2 == 0:
             raise ValueError("Resampler cannot handle 0-length vectors!")
         if size1 == self.prev1 and size2 == self.prev2: # If sizes are unchanged...
@@ -465,11 +465,11 @@ class Resampler():
             else:
                 current = [idx1, idx2, self.q]
                 self.vmap.append(current)
-        # print "Initialized vmap, length={}".format(len(self.vmap))
+        # print("Initialized vmap, length={}".format(len(self.vmap)))
         # self.idxs1 = [ int(i * self.q) for i in range(self.steps) ]
         # self.idxs2 = [ int(i * self.p) for i in range(self.steps) ]
-        # print self.idxs1
-        # print self.idxs2
+        # print(self.idxs1)
+        # print(self.idxs2)
         self.vec2 = []
         self.prev1 = size1
         self.prev2 = size2
@@ -481,9 +481,9 @@ class Resampler():
             self.vec2[m[1]] = vec1[m[0]] * m[2]
 
         # for i in range(self.steps):
-            # print "{} => {} ({})".format(wh1, wh2, i * self.q)
-            # print "vec1[{}] * {} => vec2[{}]".format(int(wh1), self.q, int(wh2))
-            # print "{} {} {}".format(i, self.idxs2[i], self.idxs1[i])
+            # print("{} => {} ({})".format(wh1, wh2, i * self.q))
+            # print("vec1[{}] * {} => vec2[{}]".format(int(wh1), self.q, int(wh2)))
+            # print("{} {} {}".format(i, self.idxs2[i], self.idxs1[i]))
             # self.vec2[self.idxs2[i]] += vec1[self.idxs1[i]] * self.q
         return self.vec2
 
@@ -729,6 +729,6 @@ class GenomicWindower():
 def test():
     r = Resampler(9,3)
     v = range(9)
-    #print v
+    #print(v)
     return r.resample(v)
     #return r.resample([1,1,1])

--- a/annotAffy.py
+++ b/annotAffy.py
@@ -42,7 +42,7 @@ def parseAnnots():
 def main(infile, outfile):
     annots = parseAnnots()
     k = annots.keys()[0]
-    print (k, annots[k])
+    print(k, annots[k])
     (filename, col) = parseFilespec(infile)
     dcol = col+1
     sys.stderr.write("{} -> {}\n".format(filename, outfile))

--- a/bamToWig.py
+++ b/bamToWig.py
@@ -266,23 +266,23 @@ def bamToWigA_old(bamfile, trackdata):
                 if curr and (curr[1] <= p):
                     while True:
                         #out.write("{}\t{}\t-\n".format(curr[0], curr[1]))
-                        #print "Output: 2 @ {}".format(curr[1])
+                        #print("Output: 2 @ {}".format(curr[1]))
                         G.add(curr)
                         x = L.pop()
                         L.deallocate(x)
                         curr = L.current()
                         if curr is None or curr[1] > p:
                             break
-                #print "Output: 1 @ {}".format(p)
+                #print("Output: 1 @ {}".format(p))
                 # Finally output entry for this read
                 G.add((chrom, p))
                 #out.write("{}\t{}\t+\n".format(chrom, p))
                 currChrom = chrom
 
             else:
-                #print "Storing {}".format(r.pos + r.qlen - 1)
+                #print("Storing {}".format(r.pos + r.qlen - 1))
                 #L.insert((r.reference_name, r.pos + r.qlen - 1))
-                #print "Storing: 2 @ {}".format(line[1])
+                #print("Storing: 2 @ {}".format(line[1]))
                 L.insert((chrom, int(line[1])))
     finally:
         G.close()

--- a/chromCoverage.py
+++ b/chromCoverage.py
@@ -80,7 +80,7 @@ class Cov():
     allcols = False             # If true, output all columns from BED file
 
     def dump(self):
-        print "total={}, maxpos={}, effbases={}".format(self.total, self.maxpos, self.effbases)
+        print("total={}, maxpos={}, effbases={}".format(self.total, self.maxpos, self.effbases))
 
     def report(self):
         if self.chrom != "":
@@ -99,7 +99,7 @@ class Cov():
         if chrom != self.chrom:
             self.update(tot)
             self.report()
-            # print "Started chrom {}".format(chrom)
+            # print("Started chrom {}".format(chrom))
             self.chrom = chrom
         self.maxpos = pos
         self.effbases += 1
@@ -174,7 +174,7 @@ class Cov():
                         readlen = read.query_length
                         nreads += (1.0 * ov) / readlen
                         nbases += ov
-                        # print "s={}, e={}, l={}, ov={}, nr={}, nb={}".format(read.reference_start, read.reference_end, readlen, ov, nreads, nbases)
+                        # print("s={}, e={}, l={}, ov={}, nr={}, nb={}".format(read.reference_start, read.reference_end, readlen, ov, nreads, nbases))
                         # raw_input()
                     if self.allcols:
                         self.out.write("\t".join(parsed) + "\t{:.2f}\t{}\t{:.2f}\n".format(nreads, nbases, (1.0 * nbases) / (end - start)))

--- a/cols.py
+++ b/cols.py
@@ -103,11 +103,11 @@ class Cols(Script.Script):
                 self.INFILES.append(a)
         
     def processFromStream(self, filename, f):
-        # print "skipping to row {}".format(self.ROWNUM)
+        # print("skipping to row {}".format(self.ROWNUM))
         hdr = []
         row = []
         reader = csv.reader(f, delimiter=self.DELIMITER, quotechar='"')
-        # print (MODE, ROWNUM, DELIMITER, SKIP, FIRSTHDR, RAW)
+        # print(MODE, ROWNUM, DELIMITER, SKIP, FIRSTHDR, RAW)
 
         if self.FIRSTHDR:
             hdr = reader.next()
@@ -131,14 +131,14 @@ class Cols(Script.Script):
 
             if self.RAW:
                 for p in range(ncols):
-                    print row[p]
+                    print(row[p])
             elif self.FIRSTHDR:
                 for p in range(ncols):
-                    print "  {} = {}".format(hdr[p], row[p])
+                    print("  {} = {}".format(hdr[p], row[p]))
             else:
                 idx = 0 if self.ZERO else 1
                 for h in row:
-                    print "  {} = {}".format(idx, h)
+                    print("  {} = {}".format(idx, h))
                     idx += 1
 
         elif self.MODE == 'matches':

--- a/demux.py
+++ b/demux.py
@@ -144,12 +144,12 @@ def revcomp(seq):
     return rc
 
 def distance(s1, s2):
-    #print "distance {} {} \n".format(s1, s2)
+    #print("distance {} {} \n".format(s1, s2))
     d = 0
     for i in range(min(len(s1), len(s2))):
         if s1[i] != s2[i]:
             d += 1
-    # print "{} {}: {}".format(s1, s2, d)
+    # print("{} {}: {}".format(s1, s2, d))
     return d
 
 ### Classes
@@ -261,7 +261,7 @@ class BarcodeMgr():
                 if d < maxd:
                     maxd = d
                     best = bc
-        # print maxd
+        # print(maxd)
         if maxd <= maxmismatch:
             bb = self.barcodes[best]
             self.nhits += 1
@@ -367,7 +367,7 @@ class FastqReader():
                 break
             bc = self.fq.getBarcode(bclen)
             bo = dm.findBest(bc, maxmismatch=P.maxmismatch) # Barcode object
-            # print "best: " + bo.seq
+            # print("best: " + bo.seq)
             # raw_input()
             if bo:
                 self.ngood += 1
@@ -467,9 +467,9 @@ class PairedFastqReader():
             if bc1 != bc2:
                 self.nbad += 1
                 continue
-            # print "barcode: " + bc1
+            # print("barcode: " + bc1)
             bo = dm.findBest(bc1, maxmismatch=P.maxmismatch)
-            # print "best: " + bo.seq
+            # print("best: " + bo.seq)
             # raw_input()
             if bo:
                 self.ngood += 1
@@ -524,7 +524,7 @@ def doDistribute():
                 break
             label = dm.barcodeseqs[i]
             bc = dm.barcodes[label]
-            #print "writing {} to {}, {}".format(i, label, bc)
+            #print("writing {} to {}, {}".format(i, label, bc))
             #raw_input()
             bc.writeRecord(pfr.fq1, pfr.fq2)
             i += 1

--- a/dmaptools.py
+++ b/dmaptools.py
@@ -263,7 +263,7 @@ class Merger():
                 if line == None:
                     break
                 key = line[0] + ":" + line[1]
-                # print "{} -> {}".format(key, p)
+                # print("{} -> {}".format(key, p))
                 # raw_input()
                 mmap[key] = p
                 p = f.tell()
@@ -289,7 +289,7 @@ class Merger():
         nhdr1 = len(hdr1)
         nhdr2 = len(hdr2)
 
-        # print "Header lengths: {}, {}".format(nhdr1, nhdr2)
+        # print("Header lengths: {}, {}".format(nhdr1, nhdr2))
         out.write("Chrom\tPos\tC1:Avg\tC1:Stdev")
         for h in hdr1:
             out.write("\tC1:" + h)
@@ -517,8 +517,8 @@ class Histcomparer(Averager):
                                 bin = 9
                             counts[i] += 1
                             hist[bin][i] += 1
-        # print hist
-        # print counts
+        # print(hist)
+        # print(counts)
         fracs = [ [ 1.0*hist[b][i] / counts[i] for i in range(nreps) ] for b in range(10) ]
         sys.stderr.write("{} rows.\n".format(nrows))
         return (nreps, fracs)
@@ -572,7 +572,7 @@ and `pos' to its first and second elements."""
             return None
         data = readDelim(self.stream)
         if data == None:
-            # print "File {} finished.".format(self.filename)
+            # print("File {} finished.".format(self.filename))
             self.stream.close()
             self.stream = None
             return None
@@ -583,7 +583,7 @@ and `pos' to its first and second elements."""
 
     def skipToChrom(self, chrom):
         """Read lines until finding one that starts with `chrom'."""
-        # print "Skipping to chrom {} for {}".format(chrom, self.filename)
+        # print("Skipping to chrom {} for {}".format(chrom, self.filename))
         while self.chrom != chrom:
             self.readNext()
             if self.stream == None:
@@ -836,11 +836,11 @@ class DMR():
         diff = ratio1 - ratio2
         if abs(diff) < self.methdiff:
             return None
-        #print (diff, [[totC1, totT1], [totC2, totT2]])
+        #print(diff, [[totC1, totT1], [totC2, totT2]])
 
         # Compute p-value
         (odds, pval) = scipy.stats.fisher_exact([[totC1, totT1], [totC2, totT2]])
-        #print (odds, pval, diff, [[totC1, totT1], [totC2, totT2]])
+        #print(odds, pval, diff, [[totC1, totT1], [totC2, totT2]])
         if pval <= self.pval:
             return (pval, diff)
         else:

--- a/genediffmeth.py
+++ b/genediffmeth.py
@@ -182,7 +182,7 @@ Min sites: {}
 
     def writeChromGenes(self, out, reg, data, genes, chrom):
         sys.stderr.write("Writing values for {} genes on {}.\n".format(len(genes), chrom))
-        #print data[:100]
+        #print(data[:100])
         mode = self.mode
         nwritten = 0
 
@@ -190,8 +190,8 @@ Min sites: {}
             grange = g.getRegion(reg)
             if not grange:
                 continue
-            #    print g.name
-            #    print reg.regwanted
+            #    print(g.name)
+            #    print(reg.regwanted)
             #    raw_input()
             nsites = 0
             totdmc = 0.0
@@ -228,9 +228,9 @@ Min sites: {}
                             balance += -1
             # if nsites > 0:
             #     sys.stderr.write("{}: {} sites\n".format(g.name, nsites))
-            #     print datarow
-            #     print genesites
-            #     print totdmc
+            #     print(datarow)
+            #     print(genesites)
+            #     print(totdmc)
             #     raw_input()
             if nsites >= self.minsites:
                 if mode == 'avg':

--- a/inserts.py
+++ b/inserts.py
@@ -37,7 +37,7 @@ class GTFregions():
             self.entries[self.currentChrom] = self.currentRegions
         for (chrom, regions) in self.entries.iteritems():
             regions.sort(key=lambda s: s[0])
-            print "{}: {} regions.".format(chrom, len(regions))
+            print("{}: {} regions.".format(chrom, len(regions)))
 
     def parseGTF(self, filename):
         with open(filename, "r") as f:

--- a/maxgap.py
+++ b/maxgap.py
@@ -23,4 +23,4 @@ if __name__ == "__main__":
             maxg = maxgap(f)
     else:
         maxg = maxgap(sys.stdin)
-    print "Max gap: {}".format(maxg)
+    print("Max gap: {}".format(maxg))

--- a/mergeCols.py
+++ b/mergeCols.py
@@ -166,7 +166,7 @@ class Opts():
         idx = 0
         idcol = self.id
         datacol = self.dc
-        # print "datacol={}".format(datacol)
+        # print("datacol={}".format(datacol))
         for infile in self.infiles:
             sys.stderr.write("Reading {}... ".format(infile))
             nread = 0
@@ -178,7 +178,7 @@ class Opts():
                     else:
                         nread += 1
                         data = line.rstrip("\r\n").split("\t")
-                        # print data
+                        # print(data)
                         gid = data[idcol]
                         gval = data[datacol]
                         if gid in table:

--- a/methreport.py
+++ b/methreport.py
@@ -126,13 +126,13 @@ def main():
     seqs = loadSequences(infile)
     rd = refDesc(seqs.next())   # reference sequence
 
-    print "Reference sequence loaded from file `{}'.".format(infile)
-    print "{}bp, {} CG positions, {} GC positions.".format(rd.length, rd.numCGs, rd.numGCs)
+    print("Reference sequence loaded from file `{}'.".format(infile))
+    print("{}bp, {} CG positions, {} GC positions.".format(rd.length, rd.numCGs, rd.numGCs))
 
     CGarr = [ [p, 0] for p in rd.CGpositions ]
     GCarr = [ [p, 0] for p in rd.GCpositions ]
 
-    print "Reading sequences..."
+    print("Reading sequences...")
     for s in seqs:
         nreads += 1
         for p in CGarr:

--- a/methylfilter.py
+++ b/methylfilter.py
@@ -159,7 +159,7 @@ class mfrun():
             if self.writeRef:
                 of.writeSeq(self.rd.sequence, False) # don't count ref seq in number of written sequences
         if self.reportFile:
-            print "Writing report to {}".format(self.reportFile)
+            print("Writing report to {}".format(self.reportFile))
             self.reportStream = open(self.reportFile, "w")
             if self.mode == "CG":
                 self.reportStream.write("Sequence\t% CG Meth\tConv\tTot\t% GC Meth\tFilename\n")
@@ -176,7 +176,7 @@ class mfrun():
     def showOutfiles(self):
         """Show all defined output files with their ranges."""
         for of in self.outfiles:
-            print "{}% - {}% -> {}".format(of.min, of.max, of.filename)
+            print("{}% - {}% -> {}".format(of.min, of.max, of.filename))
 
     def findOutfile(self, x):
         """Find the output file for value `x'."""
@@ -189,9 +189,9 @@ class mfrun():
         tot = 0
         for of in self.outfiles:
             tot = tot + of.nout
-            print "{:5}  {}".format(of.nout, of.filename)
+            print("{:5}  {}".format(of.nout, of.filename))
         if self.summaryFile:
-            print "Writing summary to {}".format(self.summaryFile)
+            print("Writing summary to {}".format(self.summaryFile))
             with open(self.summaryFile, "w") as out:
                 out.write("Filename\tMin\tMax\tNseqs\n")
                 for of in self.outfiles:
@@ -283,21 +283,21 @@ def main():
     rd = refDesc(seqs.next(), run.excludeGCG)   # reference sequence
     run.rd = rd
 
-    print "Reference sequence loaded from file `{}'.".format(run.infile)
+    print("Reference sequence loaded from file `{}'.".format(run.infile))
     if run.excludeGCG:
-        print "Excluding GCG positions."
+        print("Excluding GCG positions.")
     else:
-        print "Not excluding GCG positions."
+        print("Not excluding GCG positions.")
     if run.mode == "CG":
-        print "{}bp, {} CG positions.".format(rd.length, rd.numCGs)
+        print("{}bp, {} CG positions.".format(rd.length, rd.numCGs))
     elif run.mode == "GC":
-        print "{}bp, {} GC positions.".format(rd.length, rd.numGCs)
+        print("{}bp, {} GC positions.".format(rd.length, rd.numGCs))
 
     try:
         run.openAll()
-        print "{} output files opened:".format(len(run.outfiles))
+        print("{} output files opened:".format(len(run.outfiles)))
         run.showOutfiles()
-        print "Parsing sequences..."
+        print("Parsing sequences...")
         
         nread = 0
         for s in seqs:
@@ -330,10 +330,10 @@ def main():
     finally:
         run.closeAll()
 
-    print "Done. {} sequences read.".format(nread)
-    print "Report:"
+    print("Done. {} sequences read.".format(nread))
+    print("Report:")
     nwritten = run.showSummary()
-    print "{} sequences written.".format(nwritten)
+    print("{} sequences written.".format(nwritten))
 
 if __name__ == "__main__":
     

--- a/pileupToBED.py
+++ b/pileupToBED.py
@@ -122,7 +122,7 @@ class PTB():
                     self.outstream.write("{}\t{}\t{}\t{}\t{}\t{}\n".format(self.currentChrom, self.startPos, self.lastPos, l, self.coverage, s))
 
     def newChrom(self, chrom, pos, cov):
-        # print "Found chrom {}".format(chrom)
+        # print("Found chrom {}".format(chrom))
         if self.repfile and self.currentChrom!= "":
             covpct = (100.0 * self.covered) / (self.covered + self.uncovered)
             uncpct = (100.0 * self.uncovered) / (self.covered + self.uncovered)

--- a/rnaseqtools.py
+++ b/rnaseqtools.py
@@ -199,7 +199,7 @@ specified, in which case it gets loaded from that file."""
             self.mixes = ['1'] * self.ncols
         else:
             self.mixes = [ m.strip(" ") for m in mixes.split(",")]
-            if len(self.mixes) <> len(self.infiles):
+            if len(self.mixes) != len(self.infiles):
                 ew("Error: the number of mixes ({}) should be equal to the number of input files ({}).\n", len(self.mixes), len(self.infiles))
                 exit(-1)
             for m in self.mixes:
@@ -336,7 +336,7 @@ Rows in which both values are 0 are ignored."""
         fx = []
         fy = []
         for b in base:
-            if b[0] <> 0 and b[1] <> 0:
+            if b[0] != 0 and b[1] != 0:
                 fx.append(b[0])
                 fy.append(b[1])
         reg = linreg(fx, fy)
@@ -350,7 +350,7 @@ Also handles different concentrations due to the use of different mixes."""
         fx = []
         fy = []
         for b in base:
-            if b[1] <> 0 and b[2] <> 0:
+            if b[1] != 0 and b[2] != 0:
                 e = self.ERCCdb.find(b[0])
                 if e:
                     fact = e.factor(self.mixes[0], self.mixes[idx-1])
@@ -383,7 +383,7 @@ Also handles different concentrations due to the use of different mixes."""
     def lnorm(self, rows, idx, slope, intercept):
         # sys.stderr.write("Normalizing column {}\n".format(idx))
         for r in rows:
-            if r[1] <> 0 and r[idx] <> 0:
+            if r[1] != 0 and r[idx] != 0:
                 r[idx] = max(0.0, (r[idx] - intercept) / slope) # RSEM doesn't like negative counts... ;)
 
     def run(self):
@@ -498,7 +498,7 @@ the identifier in the first column is in the set `ids'."""
             col += 1
 
 #        if 'ENSG00000167741' in matrix:
-#            print matrix['ENSG00000167741']
+#            print(matrix['ENSG00000167741'])
 
         # Write output file
         ew("Writing fold changes for {} to file '{}'.\n", desc, outfile)

--- a/tcalc.py
+++ b/tcalc.py
@@ -540,9 +540,9 @@ def test():
     d.dump()
     d.setNcols(3)
     d.processAllRows()
-    print d.colnames
-    print d.bindings
-    print d.variables
+    print(d.colnames)
+    print(d.bindings)
+    print(d.variables)
 
 if __name__ == "__main__":
     d = Driver("tcalc.py", version="1.0", usage=usage)


### PR DESCRIPTION
If complete python3 usage is not desired/possible let me know, and I'll drop the changes.

Made changes to improve script performance in python3 environments.

Changed print statements to print functions.
Changed diamond operators (<>) to !=  as diamond operators are not compatible with 3

Suggested future changes (dictionary interoperability):
========================================
GeneList.py:        for (chrom, cgenes) in self.genes.iteritems():
GeneList.py:        for chrom, genes in self.genes.iteritems():
Script.py:        for (code, name) in self.errorNames.iteritems():
ercc.py:        for k, e in self.entries.iteritems():
ercc.py:        for k, e in self.entries.iteritems():
inserts.py:        for (chrom, regions) in self.entries.iteritems():
mergeCols.py:            for (gid, vec) in table.iteritems():
rnaseqtools.py:        for g, gdata in self.table.iteritems():